### PR TITLE
PECI device management

### DIFF
--- a/src/backends/hwmon.rs
+++ b/src/backends/hwmon.rs
@@ -13,13 +13,11 @@ use dbus::arg::RefArg;
 use crate::{
 	DaemonState,
 	types::*,
-	devices::{
-		i2c::{
-			I2CDeviceParams,
-			I2CDeviceType,
-			get_device_type,
-			get_i2cdev,
-		},
+	devices::i2c::{
+		I2CDeviceParams,
+		I2CDeviceType,
+		get_device_type,
+		get_i2cdev,
 	},
 	powerstate::PowerState,
 	sensor,
@@ -175,9 +173,9 @@ pub async fn instantiate_sensors(daemonstate: &DaemonState, dbuspaths: &FilterSe
 			continue;
 		}
 
-		let i2cdev = {
-			let mut i2cdevs = daemonstate.i2cdevs.lock().await;
-			match get_i2cdev(&mut i2cdevs, &hwmcfg.i2c) {
+		let physdev = {
+			let mut physdevs = daemonstate.physdevs.lock().await;
+			match get_i2cdev(&mut physdevs, &hwmcfg.i2c) {
 				Ok(d) => d,
 				Err(e) => {
 					eprintln!("{}: i2c device instantiation failed: {}",
@@ -248,7 +246,7 @@ pub async fn instantiate_sensors(daemonstate: &DaemonState, dbuspaths: &FilterSe
 				SensorType::Power => (0.0, 3000.0),
 			};
 
-			let io = SensorIOCtx::new(io).with_i2cdev(i2cdev.clone());
+			let io = SensorIOCtx::new(io).with_physdev(physdev.clone());
 
 			let ctor = || {
 				Sensor::new(path, &sensorname, file.kind, &daemonstate.sensor_intfs,

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -1,3 +1,30 @@
 //! Abstractions for managing physical devices.
 
+use std::collections::HashMap;
+
+/// An object representing a dynamically-managed underlying device providing one
+/// or more sensors.
+pub enum PhysicalDevice {
+	/// An I2C device, managed via the `new_device` and
+	/// `delete_device` operations of its parent bus.
+	I2C(i2c::I2CDevice),
+}
+
 pub mod i2c;
+
+/// Lookup table for finding physical devices.  Weak<_> because we only want them kept
+/// alive by (strong, Arc<_>) references from Sensors so they get dropped when the last
+/// sensor using them goes away.
+pub struct PhysicalDeviceMap {
+	/// All dynamic I2C devices.
+	i2c: HashMap<i2c::I2CDeviceParams, std::sync::Weak<PhysicalDevice>>,
+}
+
+impl PhysicalDeviceMap {
+	/// Construct a new [`PhysicalDeviceMap`].
+	pub fn new() -> Self {
+		Self {
+			i2c: HashMap::new(),
+		}
+	}
+}

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -8,9 +8,17 @@ pub enum PhysicalDevice {
 	/// An I2C device, managed via the `new_device` and
 	/// `delete_device` operations of its parent bus.
 	I2C(i2c::I2CDevice),
+
+	/// A PECI device, managed via the (global) `rescan` and
+	/// (per-device) `remove` operations.
+	#[cfg(feature = "peci")]
+	PECI(peci::PECIDevice),
 }
 
 pub mod i2c;
+
+#[cfg(feature = "peci")]
+pub mod peci;
 
 /// Lookup table for finding physical devices.  Weak<_> because we only want them kept
 /// alive by (strong, Arc<_>) references from Sensors so they get dropped when the last
@@ -18,6 +26,10 @@ pub mod i2c;
 pub struct PhysicalDeviceMap {
 	/// All dynamic I2C devices.
 	i2c: HashMap<i2c::I2CDeviceParams, std::sync::Weak<PhysicalDevice>>,
+
+	/// PECI devices (which are always dynamic).
+	#[cfg(feature = "peci")]
+	peci: HashMap<peci::PECIDeviceParams, std::sync::Weak<PhysicalDevice>>,
 }
 
 impl PhysicalDeviceMap {
@@ -25,6 +37,9 @@ impl PhysicalDeviceMap {
 	pub fn new() -> Self {
 		Self {
 			i2c: HashMap::new(),
+
+			#[cfg(feature = "peci")]
+			peci: HashMap::new(),
 		}
 	}
 }

--- a/src/devices/peci.rs
+++ b/src/devices/peci.rs
@@ -1,0 +1,145 @@
+
+use std::{
+	path::{Path, PathBuf},
+	sync::Arc,
+};
+
+use crate::{
+	dbus_helpers::props::*,
+	types::*,
+};
+
+use super::{
+	PhysicalDevice,
+	PhysicalDeviceMap,
+};
+
+/// The top-level sysfs directory via which we interact with the kernel's PECI subsystem.
+const PECI_BUS_DIR: &str = "/sys/bus/peci";
+
+/// The kernel PECI subsystem doesn't expose a sysfs interface to instantiate a device for
+/// a given bus/address; it simply allows triggering a global rescan operation, so this
+/// isn't tied to any particular device.
+// FIXME: make async?  (can be slow if host is off)
+fn rescan() -> ErrResult<()> {
+	Ok(std::fs::write(Path::new(PECI_BUS_DIR).join("rescan"), "1")?)
+}
+
+/// The information needed to instantiate a PECI device.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PECIDeviceParams {
+	/// PECI bus number.
+	pub bus: u16,
+	/// PECI address.
+	pub address: u8,
+}
+
+impl PECIDeviceParams {
+	/// Create a [`PECIDeviceParams`] from a set of dbus properties.
+	pub fn from_dbus(cfg: &dbus::arg::PropMap) -> ErrResult<Self> {
+		let bus: u64 = *prop_get_mandatory(cfg, "Bus")?;
+		let address: u64 = *prop_get_mandatory(cfg, "Address")?;
+		Ok(Self {
+			bus: bus.try_into()?,
+			address: address.try_into()?,
+		})
+	}
+
+	/// Return the device name as employed in sysfs, e.g. `"0-30"`.
+	pub fn sysfs_name(&self) -> String {
+		format!("{}-{:02x}", self.bus, self.address)
+	}
+
+	/// Return the absolute path of the sysfs directory representing the device.
+	pub fn sysfs_device_dir(&self) -> PathBuf {
+		Path::new(PECI_BUS_DIR).join("devices").join(self.sysfs_name())
+	}
+
+	/// Test if the device is currently present, i.e. has been detected by a
+	/// [`rescan`] and not subsequently removed.
+	pub fn device_present(&self) -> bool {
+		self.sysfs_device_dir().exists()
+	}
+
+	/// Attempt to instantiate the device represented by `self`; an Ok(_)
+	/// return produces a [`PECIDevice`] that will remove the device when the
+	/// last reference to it is dropped.
+	fn instantiate_device(&self) -> ErrResult<Arc<PhysicalDevice>> {
+		// Ensure we're not dealing with a stale device left over after a
+		// crash (which we could probably actually get away with for PECI
+		// since there isn't much state to speak of maintained in the
+		// driver [or the device for that matter], but for the sake of
+		// consistency and clean slates...)
+		if self.device_present() {
+			drop(PECIDevice::new(self.clone()));
+		}
+		let physdev = PhysicalDevice::PECI(PECIDevice::new(self.clone())?);
+		Ok(Arc::new(physdev))
+	}
+}
+
+/// An instantiated PECI device.
+///
+/// Doesn't do much aside from acting as a token that keeps the device instantiated as
+/// long as it exists (its [`drop`](PECIDevice::drop) impl deletes the device).
+pub struct PECIDevice {
+	/// The parameters of the device we've instantiated.
+	pub params: PECIDeviceParams,
+}
+
+impl PECIDevice {
+	/// Construct a [`PECIDevice`] from a [`PECIDeviceParams`].
+	fn new(params: PECIDeviceParams) ->ErrResult<Self> {
+		let dev = Self { params };
+		if dev.params.device_present() {
+			return Ok(dev);
+		}
+
+		// Even if rescan() fails there's still some chance it may have
+		// found the device we're concerned with before doing so, so
+		// continue on and check for it even on error...
+		let rescan_err = rescan().err();
+
+		if dev.params.device_present() {
+			Ok(dev)
+		} else {
+			match rescan_err {
+				// Report the rescan error if there was one
+				Some(e) => Err(e),
+
+				// Otherwise a generic error message
+				None => {
+					let msg = format!("{} not found after PECI rescan",
+					                  dev.params.sysfs_name());
+					Err(err_not_found(msg))
+				},
+			}
+		}
+	}
+}
+
+impl Drop for PECIDevice {
+	/// Deletes the PECI device represented by `self` by writing to its `remove` file.
+	fn drop(&mut self) {
+		let dtor_path = self.params.sysfs_device_dir().join("remove");
+		if let Err(e) = std::fs::write(&dtor_path, "1") {
+			eprintln!("Failed to write to {}: {}", dtor_path.display(), e);
+		}
+	}
+}
+
+/// Find an existing PECI [`PhysicalDevice`] in `devmap` for the given `params`, or
+/// instantiate one and add it to `devmap` if not.
+#[cfg(feature = "peci")]
+pub fn get_pecidev(devmap: &mut PhysicalDeviceMap, params: &PECIDeviceParams)
+                   -> ErrResult<Arc<PhysicalDevice>>
+{
+	match devmap.peci.get(params).and_then(|w| w.upgrade()) {
+		Some(d) => Ok(d),
+		_ => {
+			let dev = params.instantiate_device()?;
+			devmap.peci.insert(params.clone(), Arc::downgrade(&dev));
+			Ok(dev)
+		}
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ use sensor::{
 	SensorIntfData,
 	SensorMap,
 };
-use devices::i2c::I2CDeviceMap;
+use devices::PhysicalDeviceMap;
 
 /// The dbus name claimed by the daemon.
 const DBUS_NAME: &str = "xyz.openbmc_project.OmniSensor";
@@ -134,8 +134,8 @@ pub struct DaemonState {
 	config: Mutex<SensorConfigMap>,
 	/// All extant sensors, by name (active and inactive alike).
 	sensors: Mutex<SensorMap>,
-	/// All managed (dynamic) I2C devices.
-	i2cdevs: Mutex<I2CDeviceMap>,
+	/// All managed (dynamic) physical devices.
+	physdevs: Mutex<PhysicalDeviceMap>,
 	/// Our dbus connection.
 	bus: Arc<SyncConnection>,
 	/// dbus object server registry...thing.
@@ -226,7 +226,7 @@ async fn main() -> ErrResult<()> {
 	let daemonstate = DaemonState {
 		config: Mutex::new(cfg),
 		sensors: Mutex::new(SensorMap::new()),
-		i2cdevs: Mutex::new(I2CDeviceMap::new()),
+		physdevs: Mutex::new(PhysicalDeviceMap::new()),
 		bus,
 		crossroads: SyncMutex::new(cr),
 		sensor_intfs,

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -14,7 +14,7 @@ use tokio::sync::Mutex;
 use crate::{
 	DaemonState,
 	types::*,
-	devices::i2c::I2CDevice,
+	devices::PhysicalDevice,
 	gpio::BridgeGPIO,
 	powerstate::PowerState,
 	sysfs,
@@ -235,8 +235,8 @@ pub struct SensorIOCtx {
 	io: SensorIO,
 	/// A GPIO that must be asserted before reading the sensor.
 	bridge_gpio: Option<BridgeGPIO>,
-	/// A reference to an I2C device associated with the sensor.
-	i2cdev: Option<Arc<I2CDevice>>,
+	/// A reference to physical device associated with the sensor.
+	physdev: Option<Arc<PhysicalDevice>>,
 	/// Function returning a future to await before performing an update of the sensor's value.
 	next_update: NextUpdateFn,
 }
@@ -259,7 +259,7 @@ impl SensorIOCtx {
 		Self {
 			io,
 			bridge_gpio: None,
-			i2cdev: None,
+			physdev: None,
 			next_update: Box::new(|s| Box::pin(tokio::time::sleep(s.poll_interval))),
 		}
 	}
@@ -270,9 +270,9 @@ impl SensorIOCtx {
 		self
 	}
 
-	/// Add an [`I2CDevice`] to a sensor I/O context.
-	pub fn with_i2cdev(mut self, i2cdev: Option<Arc<I2CDevice>>) -> Self {
-		self.i2cdev = i2cdev;
+	/// Add a [`PhysicalDevice`] to a sensor I/O context.
+	pub fn with_physdev(mut self, physdev: Option<Arc<PhysicalDevice>>) -> Self {
+		self.physdev = physdev;
 		self
 	}
 


### PR DESCRIPTION
With these changes PECI devices are now managed in the same more fine-grained manner that I2C devices are (previously PECI devices had been managed a bit more clumsily, with an unconditional rescan on every possible instantiation, and no removal even when the corresponding sensors went "offline").  This is facilitated by some new generalized device-management abstractions shared between both the I2C code and the PECI code.