### PR TITLE
i2c: Update supported devices

### DIFF
--- a/src/backends/hwmon.rs
+++ b/src/backends/hwmon.rs
@@ -127,7 +127,7 @@ fn name_for_label(label: &str) -> &str {
 		"pin"               => "Input Power",
 		"pout"|"power"      => "Output Power",
 		"maxpin"            => "Max Input Power",
-		"vin"|"vin1"|"vin2" => "Input Voltage",
+		"vin"               => "Input Voltage",
 		"maxvin"            => "Max Input Voltage",
 		"vout"|"in"         => "Output Voltage",
 		"vmon"              => "Auxiliary Input Voltage",

--- a/src/devices/i2c.rs
+++ b/src/devices/i2c.rs
@@ -81,6 +81,7 @@ static I2C_PMBUS_TYPES: phf::Set<&'static str> = phf_set! {
 	"ISL69225",
 	"ISL69243",
 	"ISL69260",
+	"ISL69269",
 	"LM25066",
 	"MAX16601",
 	"MAX20710",

--- a/src/devices/i2c.rs
+++ b/src/devices/i2c.rs
@@ -46,6 +46,7 @@ static I2C_HWMON_DEVICES: phf::Map<&'static str, bool> = phf_map! {
 	"TMP175"   => true,
 	"TMP421"   => true,
 	"TMP441"   => true,
+	"TMP464"   => true,
 	"TMP75"    => true,
 	"W83773G"  => true,
 };
@@ -63,10 +64,14 @@ static I2C_PMBUS_TYPES: phf::Set<&'static str> = phf_set! {
 	"ADS7830",
 	"AHE50DC_FAN",
 	"BMR490",
+	"CFFPS",
+	"CFFPS1",
+	"CFFPS2",
+	"CFFPS3",
 	"DPS800",
 	"INA219",
 	"INA230",
-	"IPSPS",
+	"IPSPS1",
 	"IR38060",
 	"IR38164",
 	"IR38263",
@@ -101,7 +106,8 @@ static I2C_PMBUS_TYPES: phf::Set<&'static str> = phf_set! {
 	"TPS53679",
 	"TPS546D24",
 	"XDPE11280",
-	"XDPE12284"
+	"XDPE12284",
+	"XDPE152C4",
 };
 
 /// Retrieve an I2CDeviceType for the given device type string.


### PR DESCRIPTION
Corresponding dbus-sensors commits:
 - 40bd6718985c ("psusensor: Add xdpe152c4 support")
 - 9a7db6af2010 ("hwmontemp: add tmp464")
 - aff100c12a82 ("PSUSensor: Rename IPSPS to IPSPS1")
 - 90ef14d8dafe ("psusensor: support ibm cffps driver")

Plus a VRM used on e3c256d4i (isl69269) and a tiny code cleanup.