### PR TITLE
Threshold index support

### DIFF
--- a/src/backends/adc.rs
+++ b/src/backends/adc.rs
@@ -130,7 +130,7 @@ pub async fn instantiate_sensors(daemonstate: &DaemonState, dbuspaths: &FilterSe
 				.with_poll_interval(adccfg.poll_interval)
 				.with_scale(adccfg.scale)
 				.with_power_state(adccfg.power_state)
-				.with_thresholds_from(&adccfg.thresholds,
+				.with_thresholds_from(&adccfg.thresholds, None,
 				                      &daemonstate.sensor_intfs.thresholds,
 				                      &daemonstate.bus)
 				.with_minval(0.0)

--- a/src/backends/external.rs
+++ b/src/backends/external.rs
@@ -190,7 +190,7 @@ pub async fn instantiate_sensors(daemonstate: &DaemonState, dbuspaths: &FilterSe
 			Sensor::new(path, &extcfg.name, extcfg.kind, &daemonstate.sensor_intfs,
 			            &daemonstate.bus, mode)
 				.with_power_state(extcfg.power_state)
-				.with_thresholds_from(&extcfg.thresholds,
+				.with_thresholds_from(&extcfg.thresholds, None,
 				                      &daemonstate.sensor_intfs.thresholds,
 				                      &daemonstate.bus)
 				.with_minval(extcfg.minvalue)

--- a/src/backends/fan.rs
+++ b/src/backends/fan.rs
@@ -171,7 +171,7 @@ pub async fn instantiate_sensors(daemonstate: &DaemonState, dbuspaths: &FilterSe
 			Sensor::new(path,&fancfg.name, SensorType::RPM, &daemonstate.sensor_intfs,
 			            &daemonstate.bus, ReadOnly)
 				.with_power_state(fancfg.power_state)
-				.with_thresholds_from(&fancfg.thresholds,
+				.with_thresholds_from(&fancfg.thresholds, None,
 				                      &daemonstate.sensor_intfs.thresholds,
 				                      &daemonstate.bus)
 				.with_minval(fancfg.minreading)

--- a/src/backends/hwmon.rs
+++ b/src/backends/hwmon.rs
@@ -253,7 +253,7 @@ pub async fn instantiate_sensors(daemonstate: &DaemonState, dbuspaths: &FilterSe
 				            &daemonstate.bus, ReadOnly)
 					.with_poll_interval(hwmcfg.poll_interval)
 					.with_power_state(hwmcfg.power_state)
-					.with_thresholds_from(&hwmcfg.thresholds,
+					.with_thresholds_from(&hwmcfg.thresholds, Some(idx + 1),
 					                      &daemonstate.sensor_intfs.thresholds,
 					                      &daemonstate.bus)
 					.with_minval(minval)

--- a/src/backends/peci.rs
+++ b/src/backends/peci.rs
@@ -135,7 +135,7 @@ async fn instantiate_sensor(daemonstate: &DaemonState, path: &InventoryPath,
 		Sensor::new(path, &name, file.kind, &daemonstate.sensor_intfs,
 			    &daemonstate.bus, ReadOnly)
 			.with_power_state(PowerState::BiosPost)
-			.with_thresholds_from(&cfg.thresholds,
+			.with_thresholds_from(&cfg.thresholds, None,
 					      &daemonstate.sensor_intfs.thresholds,
 					      &daemonstate.bus)
 			.with_minval(-128.0)

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 /// An object representing a dynamically-managed underlying device providing one
 /// or more sensors.
+#[allow(clippy::upper_case_acronyms)]
 pub enum PhysicalDevice {
 	/// An I2C device, managed via the `new_device` and
 	/// `delete_device` operations of its parent bus.

--- a/src/devices/i2c.rs
+++ b/src/devices/i2c.rs
@@ -325,7 +325,7 @@ impl I2CDevice {
 		// Try to create it: 'echo $devtype $addr > .../i2c-$bus/new_device'
 		let ctor_path = dev.params.loc.sysfs_bus_dir().join("new_device");
 		let payload = format!("{} {:#02x}\n", devtype, dev.params.loc.address);
-		std::fs::write(&ctor_path, payload)?;
+		std::fs::write(ctor_path, payload)?;
 
 		// Check if that created the requisite sysfs directory
 		if dev.params.device_present() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ where H: FnOnce(dbus::message::Message, String,
 		}
 	});
 
-	tokio::spawn(async { stream.await });
+	tokio::spawn(stream);
 
 	Ok(signal)
 }

--- a/src/powerstate.rs
+++ b/src/powerstate.rs
@@ -243,7 +243,7 @@ pub mod host_state {
 			};
 			let stream = stream.for_each(handler);
 			signals.push(signal);
-			tokio::spawn(async { stream.await });
+			tokio::spawn(stream);
 		}
 
 		Ok(signals)

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -444,10 +444,14 @@ impl Sensor {
 	///
 	/// The thresholds are constructed from the provided config data, interfaces, and
 	/// dbus connection.
-	pub fn with_thresholds_from(mut self, cfg: &[ThresholdConfig],
+	///
+	/// If `index` is not `None`, entries in `cfg` with a non-`None` `index` value
+	/// that differs from it are ignored.
+	pub fn with_thresholds_from(mut self, cfg: &[ThresholdConfig], index: Option<usize>,
 	                            threshold_intfs: &ThresholdIntfDataArr,
 	                            conn: &Arc<SyncConnection>) -> Self {
-		self.thresholds = threshold::get_thresholds_from_configs(cfg, threshold_intfs,
+		self.thresholds = threshold::get_thresholds_from_configs(cfg, index,
+		                                                         threshold_intfs,
 		                                                         &self.dbuspath, conn);
 		self
 	}

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -45,6 +45,7 @@ use crate::backends::external;
 
 /// The type of a sensor.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum SensorType {
 	Temperature,
 	RPM,
@@ -129,6 +130,7 @@ impl SensorType {
 }
 
 /// An enum of config data all supported sensor types.
+#[allow(clippy::upper_case_acronyms)]
 pub enum SensorConfig {
 	#[cfg(feature = "hwmon")]
 	Hwmon(hwmon::HwmonSensorConfig),
@@ -204,8 +206,7 @@ impl SensorConfig {
 			            .map(SensorConfig::External));
 		}
 
-		return Some(Err(err_unsupported(format!("unsupported Configuration type '{}'",
-		                                        cfgtype))));
+		Some(Err(err_unsupported(format!("unsupported Configuration type '{}'", cfgtype))))
 	}
 }
 

--- a/src/threshold.rs
+++ b/src/threshold.rs
@@ -240,12 +240,17 @@ impl Threshold {
 pub type ThresholdArr = ThresholdSeverityArray<Option<Threshold>>;
 
 /// Construct a [`ThresholdArr`] from a slice of config objects.
-pub fn get_thresholds_from_configs(cfgs: &[ThresholdConfig], threshold_intfs: &ThresholdIntfDataArr,
+pub fn get_thresholds_from_configs(cfgs: &[ThresholdConfig], index: Option<usize>,
+                                   threshold_intfs: &ThresholdIntfDataArr,
                                    dbuspath: &Arc<SensorPath>, conn: &Arc<SyncConnection>)
                                    -> ThresholdArr
 {
 	let mut thresholds = ThresholdArr::default();
 	for cfg in cfgs {
+		match (index, cfg.index) {
+			(Some(x), Some(y)) if x != y => continue,
+			_ => (),
+		};
 		let intf = &threshold_intfs[cfg.severity as usize];
 		let Ok(bounds) = ThresholdBoundType::iter()
 			.map(|t| ThresholdBound::new(&intf.msgfns.bounds[t as usize], dbuspath, conn))


### PR DESCRIPTION
This fixes a problem where on romed8hm3 (which has an E-M config with an `Index` specified on the thresholds in its nct6779 config block) thresholds were getting applied to sensors they where shouldn't have been.  (It also starts off with a commit cleaning up some unrelated clippy lints.)