### PR TITLE
Add hack for inconsistently-typed PollRate parameters on dbus

### DIFF
--- a/src/backends/adc.rs
+++ b/src/backends/adc.rs
@@ -60,7 +60,7 @@ impl ADCSensorConfig {
 	                 intfs: &HashMap<String, dbus::arg::PropMap>) -> ErrResult<Self> {
 		let name: &String = prop_get_mandatory(basecfg, "Name")?;
 		let index: u64 = *prop_get_mandatory(basecfg, "Index")?;
-		let poll_sec: u64 = *prop_get_default(basecfg, "PollRate", &1u64)?;
+		let poll_sec: f64 = prop_get_default_num(basecfg, "PollRate", 1.0)?;
 		let scale: f64 = *prop_get_default(basecfg, "ScaleFactor", &1.0f64)?;
 		let power_state = prop_get_default_from(basecfg, "PowerState", PowerState::Always)?;
 		let bridge_gpio = match intfs.get(BRIDGE_GPIO_CONFIG_INTF) {
@@ -78,7 +78,7 @@ impl ADCSensorConfig {
 		Ok(Self {
 			name: name.clone(),
 			index,
-			poll_interval: Duration::from_secs(poll_sec),
+			poll_interval: Duration::from_secs_f64(poll_sec),
 			scale: 1.0 / scale, // convert to a multiplier
 			power_state,
 			thresholds,

--- a/src/backends/hwmon.rs
+++ b/src/backends/hwmon.rs
@@ -61,8 +61,8 @@ impl HwmonSensorConfig {
 		let name: &String = prop_get_mandatory(basecfg, "Name")?;
 		let mut name_overrides: HashMap<String, String> = HashMap::new();
 		let r#type = prop_get_mandatory::<String>(basecfg, "Type")?.clone();
-		let poll_sec: u64 = *prop_get_default(basecfg, "PollRate", &1u64)?;
-		let poll_interval = Duration::from_secs(poll_sec);
+		let poll_sec: f64 = prop_get_default_num(basecfg, "PollRate", 1.0)?;
+		let poll_interval = Duration::from_secs_f64(poll_sec);
 		let power_state = prop_get_default_from(basecfg, "PowerState", PowerState::Always)?;
 		let mut names = vec![name.clone()];
 		for i in 1.. {


### PR DESCRIPTION
Entity-manager, unfortunately, doesn't always present its parameters with the same types on dbus -- specifically, for instance, `PollRate` is sometimes a u64 (`t` on dbus) and sometimes an f64 (`d` on dbus).  These patches add a hack to accommodate it, first trying to retrieve it as a float and then falling back to a uint (and then converting that into a float internally) if that fails.