### PR TITLE
deps: Bump dbus-tokio to 0.7.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1.22", features = ["full"] }
 dbus = "~0.9.7"
-dbus-tokio = "~0.7.5"
+dbus-tokio = "~0.7.6"
 dbus-crossroads = "~0.5.2"
 futures = "0.3"
 gpiocdev = "0.7"


### PR DESCRIPTION
This release fixes a potential deadlock in message handling (see [1]).

[1] https://github.com/diwic/dbus-rs/commit/a6a744a7c67c16cb37b74c8155a0b6538a83979d